### PR TITLE
Move to synchronous 'after-' hooks.

### DIFF
--- a/src/OutputHash.js
+++ b/src/OutputHash.js
@@ -59,12 +59,11 @@ OutputHash.prototype.apply = function apply(compiler) {
         // Webpack does not pass chunks and assets to any compilation step, but we need both.
         // To get them, we hook into 'optimize-chunk-assets' and save the chunks for processing
         // them later.
-        compilation.plugin('optimize-chunk-assets', (chunks, done) => {
+        compilation.plugin('after-optimize-chunk-assets', (chunks) => {
             this.chunks = chunks;
-            done();
         });
 
-        compilation.plugin('optimize-assets', (assets, done) => {
+        compilation.plugin('after-optimize-assets', (assets) => {
             const nameMap = {};
 
             this.chunks
@@ -84,8 +83,6 @@ OutputHash.prototype.apply = function apply(compiler) {
                     replaceHashes(chunk, assets, nameMap);
                     reHashChunk(chunk, assets);
                 });
-
-            done();
         });
     });
 


### PR DESCRIPTION
Fixes an incompatibility with [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity).