### PR TITLE
Partial support for source-maps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
     "extends": "airbnb-base",
     "env": {
-        "node": true,
-        "mocha": true
+        "node": true
     },
     "rules": {
         // http://eslint.org/docs/rules/indent

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,16 @@
 
         // http://eslint.org/docs/rules/no-underscore-dangle
         // Allow references starting with underscore. Webpack has those.
-        "no-underscore-dangle": ["off"]
+        "no-underscore-dangle": ["off"],
+
+        // http://eslint.org/docs/rules/comma-dangle
+        // Overwrites airbnb-base config to ignore trailing commas in function calls
+        "comma-dangle": ["error", {
+            "arrays": "always-multiline",
+            "objects": "always-multiline",
+            "imports": "always-multiline",
+            "exports": "always-multiline",
+            "functions": "ignore"
+        }]
     }
 }

--- a/src/OutputHash.js
+++ b/src/OutputHash.js
@@ -115,8 +115,10 @@ OutputHash.prototype.apply = function apply(compiler) {
                 .filter(chunk => this.manifestFiles.includes(chunk.name))
                 .forEach((chunk) => {
                     chunk.files.forEach((file) => {
-                        Object.entries(nameMap).forEach(([oldHash, newHash]) =>
-                            replaceStringInAsset(assets[file], oldHash, newHash));
+                        Object.keys(nameMap).forEach((oldHash) => {
+                            const newHash = nameMap[oldHash];
+                            replaceStringInAsset(assets[file], oldHash, newHash);
+                        });
                     });
                     reHashChunk(chunk, assets, hashFn);
                 });

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,10 +1,18 @@
 {
+    "env": {
+        "node": true,
+        "mocha": true
+    },
     "plugins": [
         "mocha"
     ],
     "rules": {
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
         // Allow dynamic require(), we use it in the tests
-        "import/no-dynamic-require": ["off"]
+        "import/no-dynamic-require": ["off"],
+
+        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-exclusive-tests.md
+        // Disallow .only tests
+        "mocha/no-exclusive-tests": ["error"]
     }
 }

--- a/test/sourcemap/entry.js
+++ b/test/sourcemap/entry.js
@@ -1,0 +1,2 @@
+/* global document */
+document.write('This is a test');

--- a/test/sourcemap/webpack.config.js
+++ b/test/sourcemap/webpack.config.js
@@ -1,0 +1,19 @@
+const OutputHash = require('../../src/OutputHash.js');
+const path = require('path');
+
+const rel = (paths => path.resolve(__dirname, ...paths));
+
+module.exports = {
+    entry: {
+        entry: rel`./entry.js`,
+    },
+    devtool: 'sourcemap',
+    output: {
+        path: rel`../tmp`,
+        filename: '[name].[chunkhash].js',
+        sourceMapFilename: '[name].[chunkhash].js.map',
+    },
+    plugins: [
+        new OutputHash(),
+    ],
+};

--- a/test/test.js
+++ b/test/test.js
@@ -129,4 +129,23 @@ describe('OutputHash', () => {
                 expect(commons.source()).to.contain(hash);
             });
         }));
+
+    it.only('Works with sourcemaps', () => webpackCompile('sourcemap')
+        .then((stats) => {
+            const assets = stats.compilation.assets;
+
+            // New hash
+            expect(assets).to.have.property('entry.d36dd5d3312b77a32d66.js');
+
+            // Sourcemap still uses the old hash
+            expect(assets).to.have.property('entry.c72f41ea29f35ab86a6b.js.map');
+
+            // Source code still points to the old sourcemap
+            expect(assets['entry.d36dd5d3312b77a32d66.js'].source())
+                .to.contain('sourceMappingURL=entry.c72f41ea29f35ab86a6b.js.map');
+
+            // But sourcemaps has the name of the new source code file
+            expect(assets['entry.c72f41ea29f35ab86a6b.js.map'].source())
+                .to.contain('entry.d36dd5d3312b77a32d66.js');
+        }));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -130,7 +130,7 @@ describe('OutputHash', () => {
             });
         }));
 
-    it.only('Works with sourcemaps', () => webpackCompile('sourcemap')
+    it('Works with sourcemaps', () => webpackCompile('sourcemap')
         .then((stats) => {
             const assets = stats.compilation.assets;
 


### PR DESCRIPTION
Partial support for sourcemaps. It won't change the name of the sourcemap, but it will change the content to point to the correct re-hashed source code.