### PR TITLE
Added support for code splitting.

### DIFF
--- a/src/OutputHash.js
+++ b/src/OutputHash.js
@@ -125,24 +125,26 @@ OutputHash.prototype.apply = function apply(compiler) {
 
         compilation.plugin('after-optimize-assets', (assets) => {
             // Sort non-manifest chunks according to their parent dependencies.
-            const nonManifestChunks = this.chunks.filter(chunk => !this.manifestFiles.includes(chunk.name));
+            const nonManifestChunks = this.chunks.filter(
+                chunk => !this.manifestFiles.includes(chunk.name)
+            );
             const chunksByDependency = [];
 
-            while(nonManifestChunks.length) {
+            while (nonManifestChunks.length) {
                 let i = 0;
 
-                while(i < nonManifestChunks.length) {
+                while (i < nonManifestChunks.length) {
                     const current = nonManifestChunks[i];
 
                     if (
                         !current.parents
                         || current.parents.length === 0
-                        || current.parents.every(i => chunksByDependency.indexOf(i) !== -1)
+                        || current.parents.every(parent => chunksByDependency.indexOf(parent) !== -1)
                     ) {
                         chunksByDependency.push(current);
                         nonManifestChunks.splice(i, 1);
                     } else {
-                        i++;
+                        i += 1;
                     }
                 }
             }

--- a/src/OutputHash.js
+++ b/src/OutputHash.js
@@ -139,7 +139,10 @@ OutputHash.prototype.apply = function apply(compiler) {
                     if (
                         !current.parents
                         || current.parents.length === 0
-                        || current.parents.every(p => chunksByDependency.indexOf(p) !== -1)
+                        || current.parents.every(p =>
+                            chunksByDependency.indexOf(p) !== -1
+                            || nonManifestChunks.indexOf(p) === -1
+                        )
                     ) {
                         chunksByDependency.push(current);
                         nonManifestChunks.splice(i, 1);

--- a/src/OutputHash.js
+++ b/src/OutputHash.js
@@ -139,7 +139,7 @@ OutputHash.prototype.apply = function apply(compiler) {
                     if (
                         !current.parents
                         || current.parents.length === 0
-                        || current.parents.every(parent => chunksByDependency.indexOf(parent) !== -1)
+                        || current.parents.every(p => chunksByDependency.indexOf(p) !== -1)
                     ) {
                         chunksByDependency.push(current);
                         nonManifestChunks.splice(i, 1);

--- a/test/code-split/entry.js
+++ b/test/code-split/entry.js
@@ -1,0 +1,5 @@
+/* global document */
+document.write('This is a test');
+require.ensure([], (require) => {
+    require('./on-demand');
+});

--- a/test/code-split/on-demand.js
+++ b/test/code-split/on-demand.js
@@ -1,0 +1,2 @@
+/* global document */
+document.write('This is an on-demand chunk');

--- a/test/code-split/webpack.config.js
+++ b/test/code-split/webpack.config.js
@@ -1,0 +1,15 @@
+const OutputHash = require('../../src/OutputHash.js');
+const path = require('path');
+
+const rel = (paths => path.resolve(__dirname, ...paths));
+
+module.exports = {
+    entry: rel`./entry.js`,
+    output: {
+        path: rel`../tmp`,
+        filename: '[name].[chunkhash].js',
+    },
+    plugins: [
+        new OutputHash(),
+    ],
+};

--- a/test/test.js
+++ b/test/test.js
@@ -148,4 +148,13 @@ describe('OutputHash', () => {
             expect(assets['entry.c72f41ea29f35ab86a6b.js.map'].source())
                 .to.contain('entry.d36dd5d3312b77a32d66.js');
         }));
+
+    it('Works with code splitting', () => webpackCompile('code-split')
+        .then((stats) => {
+            const assets = stats.compilation.assets;
+
+            // Source code uses new hash for on-demand chunk
+            expect(assets['main.69f369e6b3e71c6dd26e.js'].source())
+                .to.contain('7236d0ffabbdb3276859');
+        }));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -151,10 +151,11 @@ describe('OutputHash', () => {
 
     it('Works with code splitting', () => webpackCompile('code-split')
         .then((stats) => {
-            const assets = stats.compilation.assets;
+            const main = findAssetByName(stats.compilation.assets, 'main');
+            const onDemandChunk = stats.compilation.chunks.filter(c => c.name === null)[0];
 
             // Source code uses new hash for on-demand chunk
-            expect(assets['main.69f369e6b3e71c6dd26e.js'].source())
-                .to.contain('7236d0ffabbdb3276859');
+            expect(main.source())
+                .to.contain(onDemandChunk.renderedHash);
         }));
 });


### PR DESCRIPTION
The issue is that in case of code splitting on-demand chunks are referenced by name inside of parent chunks. We need to make sure that:

1. We calculate on-demand chunk name before we use it inside of parent chunk
2. We replace old hash of on-demand chunk for new hash in parent chunk

To do that we order chunks based on their parents. That is the one not having parents goes first and the one depending on more parents goes last. Then we revert the order as the last chunk was the most referred to, hence its hash should be calculated earlier then its parents' hash.

After that we proceed with business as usual, except for now we replace hashes not only in manifest files, but in chunks as well.