### PR TITLE
support integration with webpack-subresource-integrity plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ module.exports = {
 };
 ```
 
+### `options.recalculateManifestFilesHash`
+
+`boolean`, defaults to `false`.
+
+In order to integrate this plugin with [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) plugin (or with any other plugin that might change manifest file output and must run in the last compilation step) without breaking **Long Term Caching** set this `true`.
+
+The problem is that [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) must be the last to run because it has to know the final hashes of the files.
+Then, it injects the calculated values into the manifest files.
+As a result, the filename which is an hash of the content isn't valid anymore.  
+Setting this option to true, makes the plugin recalculate the hashes of the manifest files at the emit phase which makes them valid again.
+
 ### `options.validateOutput`
 
 `boolean`, defaults to `false`.


### PR DESCRIPTION
Hi, this adds support for integration with plugins (like the [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity)) that has to run last as well and can change the manifest files output.

Basically, it makes this plugin to support long term caching with sub resource integrity.

The current integration is broken because this plugin runs after the [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) plugin (which listens to the `this-compilation` hook instead of the `compilation` hook as [can be seen here](https://webpack.js.org/api/compiler/#event-hooks)):
* sub resource integrity is wrong because the content of files is being changed by this plugin after the hash calculation.

In order to fix it, there is need to:
1. make the [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) plugin listen on the `compilation` hook so it can run after this plugin (and all others) -> this way the hashes of all sub resources will be correct. I submitted [this PR](https://github.com/waysact/webpack-subresource-integrity/pull/60).
2. since the [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) plugin now runs after the `webpack-plugin-hash-output` plugin and edits only the manifest files, there is need to run the `webpack-plugin-hash-output` plugin again only for the manifest files in order to recalculate the filenames to be based on the updated content => this PR adds that option.