### PR TITLE
Take oldChunkName from forEach arg

### DIFF
--- a/src/OutputHash.js
+++ b/src/OutputHash.js
@@ -58,8 +58,7 @@ function reHashChunk(chunk, assets, hashFn, nameMap) {
     const isMainFile = file => file.endsWith('.js') || file.endsWith('.css');
 
     // Update the name of the main files
-    chunk.files.filter(isMainFile).forEach((file, index) => {
-        const oldChunkName = chunk.files[index];
+    chunk.files.filter(isMainFile).forEach((oldChunkName, index) => {
         const asset = assets[oldChunkName];
         const { fullHash, shortHash: newHash } = hashFn(asset.source());
 


### PR DESCRIPTION
Not sure if there is a reason for the current behavior. Looks to me like a bug waiting to happen. If chunk.files starts with a filename that doesn't match isMainFile, oldChunkName won't match (index after filter is different to before filter).