### PR TITLE
feature(sourcemap&cssMinify)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,9 @@ const makeHashFn = ({
     hashDigestLength = 20,
     hashSalt = null,
 } = {}) => input => {
+    // generate hash of content without sourcemap
+    const mapCommentReg = /\s\/[\/|*]#\s?sourceMappingURL=.*.map(\s\*\/)?/g;
+    input = input.replace(mapCommentReg, '');
     const hashObj = crypto.createHash(hashFunction).update(input);
     if (hashSalt) hashObj.update(hashSalt);
     const fullHash = hashObj.digest(hashDigest);


### PR DESCRIPTION
feature(sourcemap&cssMinify):
1. sourcemap support
  - ignore sourcemap inline comment while generate hash
  - replace content file inline sourcemap comment hash to new hash
  - change sourcemap file  to have new hash
2. support optimize-cssnano-plugin(minify css plugin).We should generate hash after this plugin
  - support optimize-cssnano-plugin in function `replaceStringInAsset`
  - when set optimize-cssnano-plugin disable sourcemap, css map in assets will be deleted 