### PR TITLE
Support filtering which files are scanned for hash replacement as an optimisation 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
   - 6
+  - 10
+  - 12
 cache: yarn

--- a/test/partial-replacement-with-error/async-1.js
+++ b/test/partial-replacement-with-error/async-1.js
@@ -1,0 +1,2 @@
+/* global document */
+document.write('This is a test');

--- a/test/partial-replacement-with-error/entry-1.js
+++ b/test/partial-replacement-with-error/entry-1.js
@@ -1,0 +1,5 @@
+/* global document */
+document.write('This is a test');
+require.ensure([], require => {
+    require('./async-1');
+});

--- a/test/partial-replacement-with-error/webpack.config.js
+++ b/test/partial-replacement-with-error/webpack.config.js
@@ -1,0 +1,24 @@
+const OutputHash = require('../../src/OutputHash.js');
+const path = require('path');
+const baseConfig = require('../base.webpack.config');
+
+const rel = paths => path.resolve(__dirname, ...paths);
+
+module.exports = Object.assign({}, baseConfig, {
+    entry: {
+        entry1: rel`./entry-1.js`,
+    },
+    optimization: Object.assign({}, baseConfig.optimization, {
+        runtimeChunk: { name: 'manifest' },
+        splitChunks: {
+            chunks: 'all',
+            minChunks: 1,
+            minSize: 1,
+        },
+    }),
+    plugins: [
+        new OutputHash({
+            replacementFilterRegex: /bad-filter\..*\.js$/,
+        }),
+    ],
+});

--- a/test/partial-replacement/async-1.js
+++ b/test/partial-replacement/async-1.js
@@ -1,0 +1,2 @@
+/* global document */
+document.write('This is a test');

--- a/test/partial-replacement/entry-1.js
+++ b/test/partial-replacement/entry-1.js
@@ -1,0 +1,5 @@
+/* global document */
+document.write('This is a test');
+require.ensure([], require => {
+    require('./async-1');
+});

--- a/test/partial-replacement/webpack.config.js
+++ b/test/partial-replacement/webpack.config.js
@@ -1,0 +1,24 @@
+const OutputHash = require('../../src/OutputHash.js');
+const path = require('path');
+const baseConfig = require('../base.webpack.config');
+
+const rel = paths => path.resolve(__dirname, ...paths);
+
+module.exports = Object.assign({}, baseConfig, {
+    entry: {
+        entry1: rel`./entry-1.js`,
+    },
+    optimization: Object.assign({}, baseConfig.optimization, {
+        runtimeChunk: { name: 'manifest' },
+        splitChunks: {
+            chunks: 'all',
+            minChunks: 1,
+            minSize: 1,
+        },
+    }),
+    plugins: [
+        new OutputHash({
+            replacementFilterRegex: /manifest\..*\.js$/,
+        }),
+    ],
+});

--- a/test/test.js
+++ b/test/test.js
@@ -185,6 +185,18 @@ describe('OutputHash', () => {
                     expect(console.warn.called).to.be.true;
                 });
             });
+
+            it('Works when only replacing hashes in manifest files', () => {
+                webpackCompile('partial-replacement', mode).then(sanityCheck);
+            });
+
+            it('Safety net works when only missing hashes with partial replacement', () =>
+                webpackCompile('partial-replacement-with-error', mode)
+                    .then(() => expect.fail('Did not expect compilation to pass'))
+                    .catch(err => {
+                        expect(err.message).to.include('Some files still had the old hashes');
+                        expect(err.message).to.include('manifest.');
+                    }));
         });
     });
 });


### PR DESCRIPTION
Lets you restrict which files have their _contents_ checked for hashes. For example, if you know that only your "manifest" contains hashes this can significantly speed up the plugin.

Includes a safety net if this feature is used to check all files at the end for the old hashes in a single pass.